### PR TITLE
Fixed a few things that kept popping up errors when they shouldn't have been.

### DIFF
--- a/mq/datatype/_achievement.lua
+++ b/mq/datatype/_achievement.lua
@@ -26,6 +26,12 @@ function achievement.Objective(description) end
 function achievement.Objective(id) end
 ---@diagnostic enable: duplicate-set-field
 
+---Find an objective by it's Index in the Achievement
+---@param id integer|string
+---@return achievementobj
+function achievement.ObjectiveByIndex(id) end
+
+
 ---Generate an cheivement link.  An optional name can be
 ---provided to display in the achievement, otherwise the
 ---current character's name will be used.

--- a/mq/datatype/_character.lua
+++ b/mq/datatype/_character.lua
@@ -1,3 +1,5 @@
+--- @meta character
+
 ---@class character : spawn
 ---@field public AAExp MQFloat #AA exp as a raw number out of 10,000 (10,000=100%)
 ---@field public AAPoints MQFloat #Unused AA points
@@ -348,11 +350,13 @@ function character.Book(name) end
 function character.Book(slot) end
 
 ---@diagnostic enable: duplicate-set-field
+---@diagnostic disable: redundant-parameter
 
 ---@param bindPointIndex integer # Your bind points (0-4)
 ---@return worldlocation
 function character.BoundLocation(bindPointIndex) end
 
+---@diagnostic enable: redundant-parameter
 ---@diagnostic disable: duplicate-set-field
 ---@param name string # Name of the buff
 ---@return MQBuff

--- a/mq/datatype/_corpse.lua
+++ b/mq/datatype/_corpse.lua
@@ -1,3 +1,5 @@
+--- @meta corpse
+
 ---@class corpse : spawn # Data related to the current lootable corpse.  See [Corpse](https://docs.macroquest.org/reference/top-level-objects/tlo-corpse/)
 ---@field public Items MQFloat # Number of items on the corpse
 ---@field public Open MQBoolean # Corpse open?

--- a/mq/datatype/_fellowship.lua
+++ b/mq/datatype/_fellowship.lua
@@ -1,3 +1,5 @@
+--- @meta fellowship
+
 --- @class fellowship
 --- @field public Campfire MQBoolean #TRUE if campfire is up, FALSE if not
 --- @field public CampfireDuration ticks | fun(): ticks Time left on current campfire

--- a/mq/datatype/_friends.lua
+++ b/mq/datatype/_friends.lua
@@ -1,3 +1,5 @@
+--- @meta friends
+
 --- @class friends
 --- @field public ToString MQString # Number of friends on your friends list
 local friends = nil

--- a/mq/datatype/_group.lua
+++ b/mq/datatype/_group.lua
@@ -1,3 +1,5 @@
+--- @meta group
+
 --- @class group
 --- @field public AnyoneMissing MQBoolean # TRUE if someone is missing in group, offline, in other zone or simply just dead
 --- @field public CasterMercCount MQFloat # Count of how many Caster DPS mercenaries are in your group

--- a/mq/datatype/_math.lua
+++ b/mq/datatype/_math.lua
@@ -1,3 +1,5 @@
+---@meta math
+
 --- @class math
 --- @field public Abs fun(number: number|string): MQFloat The absolute value of the result of n
 --- @field public Acos fun(degrees: number|string): MQFloat Arccosine of n (in degrees)

--- a/mq/datatype/_raid.lua
+++ b/mq/datatype/_raid.lua
@@ -1,4 +1,7 @@
+---@meta raid
+
 ---@diagnostic disable: duplicate-set-field
+---@diagnostic disable: redundant-parameter
 
 ---@meta
 ---@class raid
@@ -43,3 +46,7 @@ function raid.Looter(index) end
 ---@param index integer|string
 ---@return raidmember
 function raid.MainAssist(index) end
+
+---@diagnostic enable: duplicate-set-field
+---@diagnostic enable: redundant-parameter
+

--- a/mq/datatype/_range.lua
+++ b/mq/datatype/_range.lua
@@ -1,3 +1,6 @@
+---@meta range
+
+
 --- @class range
 range = nil
 

--- a/mq/datatype/_spawn.lua
+++ b/mq/datatype/_spawn.lua
@@ -5,7 +5,7 @@
 ---@field public ActorDef MQString # Actor Defintion
 ---@field public Address MQFloat # Unknown?
 ---@field public AFK MQBoolean # AFK?
----@field public Aggressive MQBoolean # Returns TRUE or FALSE if a mob is aggressive or not
+---@field public Aggressive MQBoolean # Returns TRUE or FALSE if a mob is aggressive towards you or not
 ---@field public Animation MQFloat # Current animation ID. See Animations for a list of animations.
 ---@field public Anonymous MQBoolean # Anonymous
 ---@field public Assist MQBoolean # Current Raid or Group assist target?
@@ -159,7 +159,6 @@
 ---@field public S MQFloat # Shortcut for -Y (makes Southward positive)
 ---@field public D MQFloat # Shortcut for -Z (makes Downward positive)
 ---@field public FindBuff fun(predicate: string): MQBuff # Try find a given buff/debuff given predicate from cachedbuffs
----@field public Aggressive MQBoolean # Is the spawn aggressive towards you
 local spawn = {}
 
 ---@diagnostic disable: duplicate-set-field

--- a/mq/datatype/_spell.lua
+++ b/mq/datatype/_spell.lua
@@ -1,3 +1,5 @@
+---@meta spell
+
 --- @class spell
 --- @field public AERange MQFloat # AE range (group spells use this for their range)
 --- @field public BaseName MQString # Base name of the spell without rank information.

--- a/mq/datatype/_target.lua
+++ b/mq/datatype/_target.lua
@@ -31,6 +31,7 @@
 --- @field public Skin MQCachedBuff # Returns the name of the Skin spell if the Target has one
 --- @field public Slowed MQCachedBuff # Returns the name of the Slow spell if the Target has one
 --- @field public Snared MQCachedBuff # Returns the name of the Snare spell if the Target has one
+--- @field public SecondaryPctAggro MQInt # Returns the PctAggro of the person who is second
 --- @field public Strength MQCachedBuff # Returns the name of the Strength spell if the Target has one
 --- @field public SV MQCachedBuff # Returns the name of the Spiritual Vitality spell if the Target has one
 --- @field public Symbol MQCachedBuff # Returns the name of the Symbol spell if the Target has one

--- a/mq/datatype/_task.lua
+++ b/mq/datatype/_task.lua
@@ -11,7 +11,7 @@
 --- @field public RequiredSpell string Returns a string of the required spell to complete a objective.
 --- @field public DZSwitchID number Returns an int of the switch used in a objective.
 --- @field public ID number Returns an int of the task ID
---- @field public Step string Returns description of current step in the task
+--- @field public Step taskobjective Returns description of current step in the task
 --- @field public Select string Selects the task
 --- @field public Title string Returns name of the shared task
 --- @field public Timer ticks Returns amount of time before task expires

--- a/mq/datatype/_taskobjective.lua
+++ b/mq/datatype/_taskobjective.lua
@@ -1,0 +1,13 @@
+--- @class taskobjective
+--- @field public CurrentCount MQInt # Returns the current count of the .Type needed to complete a objective
+--- @field public DZSwitchID MQInt # Returns an int of the switch used in a objective.
+--- @field public Index MQInt # Returns the objective's place on the objectivelist
+--- @field public Instruction MQString # Returns a tasks' Objectives
+--- @field public Optional MQBoolean # Returns true or false if a objective is optional
+--- @field public RequiredCount MQInt # Returns the required count of the .Type needed to complete a objective
+--- @field public RequiredItem MQString # Returns a string of the required item to complete a objective.
+--- @field public RequiredSkill MQString # Returns a string of the required skill to complete a objective.
+--- @field public RequiredSpell MQString # Returns a string of the required spell to complete a objective.
+--- @field public Status MQString # Returns the status of the objective in the format amount done Vs total IE 0/3
+--- @field public Type MQString # Returns a string that can be one of the following:< Unknown, None, Deliver, Kill, Loot, Hail, Explore, Tradeskill, Fishing, Foraging, Cast, UseSkill, DZSwitch, DestroyObject, Collect, Dialogue
+--- @field public Zone MQString # Returns the zone the objective is to be performed in

--- a/mq/datatype/_type.lua
+++ b/mq/datatype/_type.lua
@@ -1,3 +1,5 @@
+---@meta mqtype
+
 --- @class mqtype
 --- @field public Name MQString # Type name
 --- @field public ToString MQString # Same as Name

--- a/mq/datatype/_window.lua
+++ b/mq/datatype/_window.lua
@@ -1,3 +1,5 @@
+---@meta window
+
 ---@class window
 ---@field public BGColor argb # Background color
 ---@field public Checked MQBoolean # Returns TRUE if the button has been checked

--- a/mq/mq.lua
+++ b/mq/mq.lua
@@ -134,7 +134,7 @@ function mq.imgui.destroy(name) end
 
 ---MQ2 Top Level Object Accssor
 ---@class TLO
----@field Achievement Achievement
+---@field Achievement achievementmgr
 ---@field AdvLoot AdvLoot
 ---@field Alias fun(name:string):boolean # True if alias exists
 ---@field AltAbility altability

--- a/mq/plugins/DanNet/_TLO.lua
+++ b/mq/plugins/DanNet/_TLO.lua
@@ -1,4 +1,4 @@
----@meta
+---@meta DanNet
 
 --- DanNet Lua Bindings
 ---@class TLO.DanNet
@@ -27,9 +27,14 @@ TLO.DanNet = {}
 ---@return peer|fun(): string|nil
 function TLO.DanNet(peerName) end
 
+---@diagnostic disable: redundant-parameter
 ---@param groupName string 
 ---@return string # all peers in the [groupName] group
 function TLO.DanNet.Peers(groupName) end
+
+---@diagnostic enable: redundant-parameter
+
+
 
 ---- Observe accessor
 ---@return string # List all queries observers have registered

--- a/mq/plugins/DanNet/_datatypes.lua
+++ b/mq/plugins/DanNet/_datatypes.lua
@@ -1,3 +1,5 @@
+---@meta peer
+
 ---@class observer
 ---@field Received MQInt # The last received timestamp, or 0 for never received
 

--- a/mq/plugins/NetBots/_datatypes.lua
+++ b/mq/plugins/NetBots/_datatypes.lua
@@ -1,9 +1,11 @@
+--- @meta netbot
+
 --- @class netbot
 --- @field public Name MQString #Name of Name.
 --- @field public Zone MQInt #Zone ID of Name.
 --- @field public Instance MQInt #Instance ID of Name.
---- @field public MQInt Spawn ID of Name.
---- @field public Class class Class of Name.
+--- @field public ID MQInt #Spawn ID of Name.
+--- @field public Class class #Class of Name.
 --- @field public Level MQInt #Level of Name.
 --- @field public PctExp MQFloat #Percent Experience of Name.
 --- @field public PctAAExp MQFloat #Percent AA Experience of Name.
@@ -41,7 +43,7 @@
 --- @field public Standing MQBoolean #Is Name standing?
 --- @field public Stunned MQBoolean #Is Name stunned?
 --- @field public FreeBuffSlots MQInt #Total free buff slots Name has.
---- @field public InZone MQBoolean Is Name in the same zone as you?
+--- @field public InZone MQBoolean #Is Name in the same zone as you?
 --- @field public InGroup MQBoolean #Is Name in your group?
 --- @field public Leader MQString #Is Name the group leader?
 --- @field public Note MQString #Is Name the group leader?


### PR DESCRIPTION
### mq/mq.lua:
- TLO.Achievement now outputs achievementmgr type

### mq/datatype/_achievement.lua:
- added achievement.ObjectiveByIndex(id)

### mq/datatype/_target.lua
- Was missing SecondaryPctAggro

### mq/datatype/_task.lua
- Step returns taskobjective, not string

### mq/datatype/_taskobjective.lua
- Added that datatype in

### mq/Plugins/DanNet/_datatypes.lua
- @meta peer, helps fix some yellow squigglies

### mq/plugins/DanNet/_TLO.lua
- @meta DanNet fixes squigglies
- some diagnostic stuff, too